### PR TITLE
Prepare for FreeCAD 1.0 Release new Start module...

### DIFF
--- a/Behave-Dark Colors/Behave-Dark Colors.cfg
+++ b/Behave-Dark Colors/Behave-Dark Colors.cfg
@@ -84,6 +84,9 @@
             <FCBool Name="UseStyleSheet" Value="0"/>
             <FCBool Name="NewFileGradient" Value="0"/>
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
+            <FCUInt Name="FileThumbnailBorderColor" Value="980680959"/>
+            <FCUInt Name="FileThumbnailBackgroundColor" Value="1129143295"/>
+            <FCUInt Name="FileThumbnailSelectionColor" Value="980680959"/>
           </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>

--- a/Behave-Dark Colors/Behave-Dark Colors.cfg
+++ b/Behave-Dark Colors/Behave-Dark Colors.cfg
@@ -83,6 +83,7 @@
             <FCText Name="BackgroundImage"></FCText>
             <FCBool Name="UseStyleSheet" Value="0"/>
             <FCBool Name="NewFileGradient" Value="0"/>
+            <FCBool Name="FileCardUseStyleSheet" Value="0"/>
           </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>


### PR DESCRIPTION
...while still supporting older versions of FreeCAD as the parameter names do not clash.

Before:

![Start_Before_Fix](https://github.com/user-attachments/assets/07b3abce-d733-41b9-b99b-7e77e9c6ee59)


After:

![Start_After_Fix](https://github.com/user-attachments/assets/5e4de1a4-321b-4719-a68d-d6b4250e581f)
