### PR TITLE
Sketcher, Spreadsheet, Overlay and Tesselation suggestions

### DIFF
--- a/Behave-Dark Colors/Behave-Dark Colors.cfg
+++ b/Behave-Dark Colors/Behave-Dark Colors.cfg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <FCParameters>
-
   <FCParamGroup Name="Root">
     <FCParamGroup Name="BaseApp">
       <FCParamGroup Name="Preferences">
@@ -30,7 +29,7 @@
         <FCParamGroup Name="View">
           <FCUInt Name="SketchEdgeColor" Value="3537428991"/>
           <FCUInt Name="SketchVertexColor" Value="3537428991"/>
-          <FCUInt Name="EditedEdgeColor" Value="3537428991"/>
+          <FCUInt Name="EditedEdgeColor" Value="2829625599"/>
           <FCUInt Name="EditedVertexColor" Value="4014818559"/>
           <FCUInt Name="ConstructionColor" Value="474908671"/>
           <FCUInt Name="ExternalColor" Value="3294784511"/>
@@ -45,10 +44,10 @@
           <FCUInt Name="NonDrivingConstrDimColor" Value="1790502399"/>
           <FCUInt Name="ConstrainedDimColor" Value="4014818559"/>
           <FCUInt Name="ExprBasedConstrDimColor" Value="3968890623"/>
-          <FCUInt Name="DeactivatedConstrDimColor" Value="1044862207"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2829625599"/>
           <FCUInt Name="CursorTextColor" Value="1790502399"/>
           <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
-          <FCUInt Name="CreateLineColor" Value="3537428991"/>
+          <FCUInt Name="CreateLineColor" Value="2829625599"/>
           <FCBool Name="Simple" Value="1"/>
           <FCBool Name="Gradient" Value="0"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
@@ -60,7 +59,16 @@
           <FCUInt Name="BackgroundColor4" Value="1869583359"/>
           <FCUInt Name="HighlightColor" Value="4040718847"/>
           <FCUInt Name="SelectionColor" Value="1790502399"/>
-          <FCUInt Name="DefaultShapeColor" Value="3537428991"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435980543"/>
+          <FCUInt Name="DefaultAmbientColor" Value="1431655935"/>
+          <FCUInt Name="DefaultEmissiveColor" Value="255"/>
+          <FCUInt Name="DefaultSpecularColor" Value="2290649343"/>
+          <FCInt Name="DefaultShapeTransparency" Value="0"/>
+          <FCInt Name="DefaultShapeShininess" Value="90"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="421075455"/>
+          <FCInt Name="DefaultShapeLineWidth" Value="2"/>
+          <FCUInt Name="DefaultShapeVertexColor" Value="421075455"/>
+          <FCInt Name="DefaultShapePointSize" Value="2"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="4040718847"/>
@@ -69,8 +77,15 @@
         <FCParamGroup Name="MainWindow">
           <FCBool Name="TiledBackground" Value="0"/>
           <FCText Name="StyleSheet">Behave-dark.qss</FCText>
+          <FCText Name="OverlayActiveStyleSheet">Behave-dark-overlay.qss</FCText>
         </FCParamGroup>
         <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#555500</FCText>
+            <FCText Name="TextColor">#5dba00</FCText>
+            <FCText Name="PositiveNumberColor">#5dba00</FCText>
+            <FCText Name="NegativeNumberColor">#c01000</FCText>
+          </FCParamGroup>
           <FCParamGroup Name="Start">
             <FCUInt Name="BackgroundColor1" Value="589902591"/>
             <FCUInt Name="BackgroundTextColor" Value="1853194239"/>
@@ -88,9 +103,12 @@
             <FCUInt Name="FileThumbnailBackgroundColor" Value="1129143295"/>
             <FCUInt Name="FileThumbnailSelectionColor" Value="980680959"/>
           </FCParamGroup>
+          <FCParamGroup Name="Part">
+            <FCFloat Name="MeshDeviation" Value="0.250000000000"/>
+            <FCFloat Name="MeshAngularDeflection" Value="10.000000000000"/>
+          </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>
   </FCParamGroup>
-
 </FCParameters>

--- a/Behave-Dark Colors/Behave-Dark Colors.cfg
+++ b/Behave-Dark Colors/Behave-Dark Colors.cfg
@@ -82,7 +82,7 @@
         <FCParamGroup Name="Mod">
           <FCParamGroup Name="Spreadsheet">
             <FCText Name="AliasedCellBackgroundColor">#555500</FCText>
-            <FCText Name="TextColor">#5dba00</FCText>
+            <FCText Name="TextColor">#caf1ee</FCText>
             <FCText Name="PositiveNumberColor">#5dba00</FCText>
             <FCText Name="NegativeNumberColor">#c01000</FCText>
           </FCParamGroup>

--- a/Behave-Dark Colors/Behave-Dark Colors.cfg
+++ b/Behave-Dark Colors/Behave-Dark Colors.cfg
@@ -70,6 +70,11 @@
           <FCUInt Name="DefaultShapeVertexColor" Value="421075455"/>
           <FCInt Name="DefaultShapePointSize" Value="2"/>
         </FCParamGroup>
+        <FCParamGroup Name="Themes">
+          <FCUInt Name="ThemeAccentColor1" Value="1434171135"/>
+          <FCUInt Name="ThemeAccentColor2" Value="1434171135"/>
+          <FCUInt Name="ThemeAccentColor3" Value="1434171135"/>
+        </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="4040718847"/>
           <FCUInt Name="TreeActiveColor" Value="1129143295"/>


### PR DESCRIPTION
Chris, this is more of a suggestion PR and I'll explain some of the reasoning. In the 0.22/1.0 dev cycle the default material has been changed along with  the whole material system so when in Sketch Edit mode the creation of lines including the new On View Parameters (where dimensions can be created immediately rather afterwards become difficult to see, so this is the suggestion:

![Sketcher_Changes](https://github.com/user-attachments/assets/3871d396-786b-4e69-b8ad-3d411bbab5ad)

There were no Spreadsheet text, positive number, negative number and alias colors suggested for dark backgrounds so this is something to consider, suggestion:

![Spreadsheet_colors](https://github.com/user-attachments/assets/07b5272e-1852-475f-a455-06b80a72e0ff)

I also included a less tessellated look with the Part Wb settings which don't have any noticeable performance deficit on a 12 year system. Also the new Overlay system is available which I'm perfecting over at https://github.com/FreeCAD/FreeCAD-themes/pull/4 so users of this config won't loose out and works error free on 0.21.x and 0.20.x

Like I say if you just want to cherry pick some/none of it and/or change colors to your taste that's absolutely fine.